### PR TITLE
Replace spread operator with union operator

### DIFF
--- a/src/Resources/AnnouncementResource.php
+++ b/src/Resources/AnnouncementResource.php
@@ -51,10 +51,7 @@ class AnnouncementResource extends Resource
                     ->rgb(),
 
                 Select::make('users')
-                    ->options([
-                        'all' => 'all',
-                        ...User::all()->pluck('name', 'id'),
-                    ])
+                    ->options(['all' => 'all'] + User::all()->pluck('name', 'id'))
                     ->multiple()
                     ->required(),
             ]);

--- a/src/Resources/AnnouncementResource.php
+++ b/src/Resources/AnnouncementResource.php
@@ -51,7 +51,7 @@ class AnnouncementResource extends Resource
                     ->rgb(),
 
                 Select::make('users')
-                    ->options(['all' => 'all'] + User::all()->pluck('name', 'id'))
+                    ->options(['all' => 'all'] + User::all()->pluck('name', 'id')->toArray())
                     ->multiple()
                     ->required(),
             ]);


### PR DESCRIPTION
Hi @rupadana , 

I just noticed that Users ids were not preserved when the form was submitted.

This happens because spread operator (...), just like array_merge,  is not preserving the array keys when they are numerical.

The proposed solution is to replace that with an array union operator (+).